### PR TITLE
PROD-2716: replace succeeded and failed with success and failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,45 +2,41 @@
 
 # CTO.ai GitHub Action
 
-This Github Action allows you to extend the insights data received by CTO.ai Github App. You can add data to you workflows for deployment tools that are not configured with Github's deployment API.
+This GitHub Action allows you to extend the Insights data received by the CTO.ai GitHub App. You can add data to you workflows for deployment tools that are not configured with GitHub's Deployments API.
 
 ## Required Inputs
 
 ### `token`
 
-CTO.ai api token, follow [these docs to generate](https://cto.ai/docs/integrate-any-tool)
+The `token` field should be your CTO.ai API token. You can follow [our docs to generate](https://cto.ai/docs/integrate-any-tool) your API token.
 
 ### `team_id`
 
-CTO.ai team ID sending the data, follow [these docs to access](https://cto.ai/docs/integrate-any-tool)
+Instructions for finding the CTO.ai Team ID which owns the received data can also be found [in our docs](https://cto.ai/docs/integrate-any-tool).
 
 ### `event_name`
 
-Name of event being sent i.e. "deployment"
+The name which represents the event being sent, e.g. "deployment".
 
 ### `event_action`
 
-Action associated with event i.e. "failure", "pending", or "success"
+The state resulting from the event taking action, e.g. "failure" or "success".
 
 ## Optional Inputs
 
-The following action fields are optional; however, more complex builds may
-require them.
+The following field are optional inputs to this GitHub Action, but may be required by more complex builds.
 
 ### `branch`
 
-The `branch` field refers to the git branch name where the change occurs. When
-absent, the action will use the `ref` value if available to the event type.
+The `branch` field refers to the git branch name where the change occurs. When absent, the action will use the `ref` of the branch triggering the workflow.
 
 ### `commit`
 
-The `commit` field refers to the commit id where the change occurs. When absent,
-the action will use the SHA value if available to the event type.
+The `commit` field refers to the commit hash representing the current change. When absent, the pipe will use the hash of the head commit of the branch that trigger this workflow.
 
 ### `repo`
 
-The `repo` field refers to the repository name where the change occurs. When
-absent, the action will use the repository's name where the workflow runs.
+The `repo` field refers to the name of the repository where the change is occurring. When absent, the action will use the name of the repository that initiated this workflow run.
 
 ### `environment`
 
@@ -55,14 +51,14 @@ The `image` field refers to the OCI image name or ID associated with this event.
 Create 2 new secrets for your `token` and `team_id` to be passed into the action.
 
 1. From your GitHub repo, click Settings -> Secrets -> New Secret
-2. Create `CTOAI_TEAM_ID` secret using your CTO.ai-issued Team Id.
+2. Create `CTOAI_TEAM_ID` secret using your CTO.ai-issued Team ID.
 3. Create `CTOAI_EVENTS_API_TOKEN` secret using your CTO.ai-issued API Token.
 
 ## Example Usage
 
-If you have a GitHub workflow that deploys your application (i.e. serverless, npm publish, Azure, etc), you can drop this Action in right after that step to capture the success or fail of that deployment!
+If you have a GitHub workflow that deploys your application (e.g. serverless, npm publish, Azure, etc), you can drop this Action in right after that step to capture the success or fail of that deployment!
 
-We recommend adding `environment` to help us help you differentiate multiple deployment events from the same repository to different environments or workflows. This will be reflected on your Insights Dashboard.
+We recommend adding `environment` to help differentiate multiple deployment events from the same repository to different environments or workflows. This will be reflected on your Insights Dashboard.
 
 ```yaml
 - name: Report Deployment Succeeded

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Name of event being sent i.e. "deployment"
 
 ### `event_action`
 
-Action associated with event i.e. "failed", "pending", or "succeeded"
+Action associated with event i.e. "failure", "pending", or "success"
 
 ## Optional Inputs
 
@@ -72,7 +72,7 @@ We recommend adding `environment` to help us help you differentiate multiple dep
     team_id: ${{ secrets.CTOAI_TEAM_ID }}
     token: ${{ secrets.CTOAI_EVENTS_API_TOKEN }}
     event_name: "deployment"
-    event_action: "succeeded"
+    event_action: "success"
     environment: "production"
 - name: Report Deployment Failed
   if: ${{ failure() }}
@@ -81,6 +81,6 @@ We recommend adding `environment` to help us help you differentiate multiple dep
     team_id: ${{ secrets.CTOAI_TEAM_ID }}
     token: ${{ secrets.CTOAI_EVENTS_API_TOKEN }}
     event_name: "deployment"
-    event_action: "failed"
+    event_action: "failure"
     environment: "production"
 ```


### PR DESCRIPTION
We are standardizing the `event_action` values across different integrations.